### PR TITLE
AR-159 스와이프 범위 제한 설정

### DIFF
--- a/Assets/Resources/Prefabs/UI/Popup/UIInGame.prefab
+++ b/Assets/Resources/Prefabs/UI/Popup/UIInGame.prefab
@@ -1202,7 +1202,6 @@ GameObject:
   - component: {fileID: 5247537126520344958}
   - component: {fileID: 4068127159236064995}
   - component: {fileID: 1172363477477321153}
-  - component: {fileID: 4958905271404963373}
   m_Layer: 5
   m_Name: UIInGame
   m_TagString: Untagged
@@ -1310,21 +1309,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 236dc6aba3ded844cb12a7fb41c8fa16, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4958905271404963373
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7914473891498434915}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ad83472477b4eea46af7f49a680debfd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _swipeEventAsset: {fileID: 11400000, guid: 1e25d16e4f02c33428de76573b897bc1, type: 2}
-  fruitsSpawnPosition: {fileID: 1603068324892420236}
-  nextFruitsPosition: {fileID: 2537788024902482428}
 --- !u!1 &8296056281326146266
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Fruit/ThrowFruit.cs
+++ b/Assets/Scripts/Fruit/ThrowFruit.cs
@@ -25,6 +25,19 @@ public class ThrowFruit : MonoBehaviour
         _rigidbody = GetComponent<Rigidbody>();
     }
 
+    private void Update()
+    {
+        if (Managers.FruitRandomSpawnManager.IsSwipe)
+        {
+            Managers.FruitRandomSpawnManager.IsSwipe = false;
+        }
+
+        if (Managers.FruitRandomSpawnManager.IsSwipe)
+        {
+            Managers.FruitRandomSpawnManager.IsSwipe = false;
+        }
+    }
+
     private void OnEnable()
     {
         _swipeEventAsset.eventRaised += Throw;
@@ -63,6 +76,8 @@ public class ThrowFruit : MonoBehaviour
         _rigidbody.AddForce(launchVelocity * force * speed, ForceMode.Impulse);
 
         gameObject.transform.SetParent(transform.root);
+        Managers.FruitRandomSpawnManager.SpawnFruits();
+        Managers.FruitRandomSpawnManager.EnableAllColliders(gameObject);
 
         // �� ���� Throw �ǵ��� �̺�Ʈ ���� ����
         _swipeEventAsset.eventRaised -= Throw;

--- a/Assets/Scripts/Fruit/ThrowFruit.cs
+++ b/Assets/Scripts/Fruit/ThrowFruit.cs
@@ -25,19 +25,6 @@ public class ThrowFruit : MonoBehaviour
         _rigidbody = GetComponent<Rigidbody>();
     }
 
-    private void Update()
-    {
-        if (Managers.FruitRandomSpawnManager.IsSwipe)
-        {
-            Managers.FruitRandomSpawnManager.IsSwipe = false;
-        }
-
-        if (Managers.FruitRandomSpawnManager.IsSwipe)
-        {
-            Managers.FruitRandomSpawnManager.IsSwipe = false;
-        }
-    }
-
     private void OnEnable()
     {
         _swipeEventAsset.eventRaised += Throw;

--- a/Assets/Scripts/UI/FruitRandomSpawn.cs
+++ b/Assets/Scripts/UI/FruitRandomSpawn.cs
@@ -4,13 +4,9 @@ using System.Collections.Generic;
 using UnityEngine;
 
 // 스와이프 관련 이벤트 제거 후 ThrowFruit에서 FruitRandomSpawnManager 호출 방식으로 변경
-public class FruitRandomSpawnManager : MonoBehaviour
+public class FruitRandomSpawnManager
 {
-    [SerializeField]
-    private SwipeEventAsset _swipeEventAsset;
-
-    [SerializeField] Transform fruitsSpawnPosition;
-    [SerializeField] Transform nextFruitsPosition;
+    Vector3 fruitsSpawnPosition = new Vector3(0.22f, -3f, -0.2f);
 
     private Stack<int> randomIndex = new Stack<int>();
     private GameObject currentFruit;
@@ -19,21 +15,12 @@ public class FruitRandomSpawnManager : MonoBehaviour
     public delegate void OnChangeRandom(string fruitName);
     public event OnChangeRandom OnChangeRandomEvent;
 
-    private bool isSwipe = false;
+    public bool IsSwipe {  get; set; }
 
-    private void Start()
+    public void Init()
     {
         MakeRandomIndex();
         SpawnFruits();
-
-        // 스와이프 이벤트 구독
-        _swipeEventAsset.eventRaised += OnSwipeEvent;
-    }
-
-    private void OnDestroy()
-    {
-        // 스와이프 이벤트 구독 해제
-        _swipeEventAsset.eventRaised -= OnSwipeEvent;
     }
 
     void MakeRandomIndex()
@@ -43,13 +30,16 @@ public class FruitRandomSpawnManager : MonoBehaviour
         randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length));
     }
 
-    void SpawnFruits()
+    public void SpawnFruits()
     {
         if (currentFruit != null)
         {
             // 현재 과일이 던져지면 분리
             currentFruit.transform.SetParent(null, true);
         }
+
+        // 프로토타입 이후 currentFruit랑 nextFruit 하나로 합치기
+        // 애초에 두개로 나눌 필요가 없어짐
 
         // 다음 과일을 현재 과일로 설정
         currentFruit = nextFruit;
@@ -61,7 +51,7 @@ public class FruitRandomSpawnManager : MonoBehaviour
         }
 
         // 새로운 다음 과일 생성
-        nextFruit = Managers.FruitsManager.InstantiateFruit(Managers.Data.fruits[randomIndex.Pop()], nextFruitsPosition.position);
+        nextFruit = Managers.FruitsManager.InstantiateFruit(Managers.Data.fruits[randomIndex.Pop()], fruitsSpawnPosition);
         if (nextFruit != null)
         {
             nextFruit.transform.SetParent(Camera.main.transform, false); // MainCamera의 자식으로 설정
@@ -77,33 +67,12 @@ public class FruitRandomSpawnManager : MonoBehaviour
     }
 
     // 모든 캡슐 콜라이더 활성화
-    private void EnableAllColliders(GameObject fruit)
+    public void EnableAllColliders(GameObject fruit)
     {
         CapsuleCollider[] colliders = fruit.GetComponentsInChildren<CapsuleCollider>();
         foreach (CapsuleCollider collider in colliders)
         {
             collider.enabled = true;
-        }
-    }
-
-    // 스와이프 이벤트 핸들러
-    public void OnSwipeEvent(object sender, SwipeData args)
-    {
-        if (!isSwipe)
-        {
-            // 스와이프 이벤트 발생 시 과일 업데이트
-            SpawnFruits();
-            EnableAllColliders(currentFruit);
-            isSwipe = true;
-        }
-    }
-
-    void Update()
-    {
-        // 스와이프가 완료된 후 다시 던질 수 있도록 상태 초기화
-        if (isSwipe)
-        {
-            isSwipe = false;            
         }
     }
 }

--- a/Assets/Scripts/UI/FruitRandomSpawn.cs
+++ b/Assets/Scripts/UI/FruitRandomSpawn.cs
@@ -15,8 +15,6 @@ public class FruitRandomSpawnManager
     public delegate void OnChangeRandom(string fruitName);
     public event OnChangeRandom OnChangeRandomEvent;
 
-    public bool IsSwipe {  get; set; }
-
     public void Init()
     {
         MakeRandomIndex();

--- a/Assets/Scripts/UI/Popup/UIInGame.cs
+++ b/Assets/Scripts/UI/Popup/UIInGame.cs
@@ -31,7 +31,6 @@ public class UIInGame : UIPopup
         ComboUI
     }
 
-    private FruitRandomSpawnManager fruitRandomSpawnManager;
 
     public override bool Init()
     {
@@ -43,12 +42,9 @@ public class UIInGame : UIPopup
 
         BindObject(typeof(GameObjects));
 
-        fruitRandomSpawnManager = FindObjectOfType<FruitRandomSpawnManager>();
+        Managers.FruitRandomSpawnManager.Init();
 
-        if (fruitRandomSpawnManager != null)
-        {
-            fruitRandomSpawnManager.OnChangeRandomEvent += UpdateNextFruitImage;
-        }
+        Managers.FruitRandomSpawnManager.OnChangeRandomEvent += UpdateNextFruitImage;
 
         Managers.ScoreManager.OnScoreUpdated += UpdateScoreUI;
         Managers.ScoreManager.OnComboUpdated += UpdateComboUI;
@@ -62,10 +58,8 @@ public class UIInGame : UIPopup
 
     private void OnDisable()
     {
-        if (fruitRandomSpawnManager != null)
-        {
-            fruitRandomSpawnManager.OnChangeRandomEvent -= UpdateNextFruitImage;
-        }
+
+        Managers.FruitRandomSpawnManager.OnChangeRandomEvent -= UpdateNextFruitImage;
 
         Managers.ScoreManager.OnScoreUpdated -= UpdateScoreUI;
         Managers.ScoreManager.OnComboUpdated -= UpdateComboUI;


### PR DESCRIPTION
## 작업 내용
FruitRandomSpanwer에서 스와이프 이벤트 구독으로 제어 하던 로직을 ThrowFruit에서 이미 과일 던짐 범위 제한을 만들어 놓았기 때문에 FruitRandomSpanwer에서 스와이프 관련 이벤트 제거 후 ThrowFruit에서 FruitRandomSpawnManager를 직접 호출하는 방식으로 변경
추가 코드
```CS
Managers.FruitRandomSpawnManager.SpawnFruits();
Managers.FruitRandomSpawnManager.EnableAllColliders(gameObject);
```