### PR TITLE
AR-160 게임 오버 후 씬 다시 불러올때 점수, 게임오버 여부 초기화

### DIFF
--- a/Assets/Scenes/ScoreCombo.unity
+++ b/Assets/Scenes/ScoreCombo.unity
@@ -123,101 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &82730829
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 82730832}
-  - component: {fileID: 82730831}
-  - component: {fileID: 82730830}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &82730830
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 82730829}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ab68ce6587aab0146b8dabefbd806791, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
-  m_ClickSpeed: 0.3
-  m_MoveDeadzone: 0.6
-  m_RepeatDelay: 0.5
-  m_RepeatRate: 0.1
-  m_TrackedDeviceDragThresholdMultiplier: 2
-  m_TrackedScrollDeltaMultiplier: 5
-  m_ActiveInputMode: 1
-  m_MaxTrackedDeviceRaycastDistance: 1000
-  m_EnableXRInput: 1
-  m_EnableMouseInput: 1
-  m_EnableTouchInput: 1
-  m_PointAction: {fileID: 2869410428622933342, guid: c348712bda248c246b8c49b3db54643f,
-    type: 3}
-  m_LeftClickAction: {fileID: 1855836014308820768, guid: c348712bda248c246b8c49b3db54643f,
-    type: 3}
-  m_MiddleClickAction: {fileID: -6289560987278519447, guid: c348712bda248c246b8c49b3db54643f,
-    type: 3}
-  m_RightClickAction: {fileID: -2562941478296515153, guid: c348712bda248c246b8c49b3db54643f,
-    type: 3}
-  m_ScrollWheelAction: {fileID: 5825226938762934180, guid: c348712bda248c246b8c49b3db54643f,
-    type: 3}
-  m_NavigateAction: {fileID: -7967456002180160679, guid: c348712bda248c246b8c49b3db54643f,
-    type: 3}
-  m_SubmitAction: {fileID: 3994978066732806534, guid: c348712bda248c246b8c49b3db54643f,
-    type: 3}
-  m_CancelAction: {fileID: 2387711382375263438, guid: c348712bda248c246b8c49b3db54643f,
-    type: 3}
-  m_EnableBuiltinActionsAsFallback: 1
-  m_EnableGamepadInput: 1
-  m_EnableJoystickInput: 1
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
---- !u!114 &82730831
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 82730829}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &82730832
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 82730829}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &175909074
 GameObject:
   m_ObjectHideFlags: 0
@@ -720,7 +625,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1633348872}
-  - {fileID: 1599589430}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1211827612
@@ -901,52 +805,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &1599589429
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1599589430}
-  - component: {fileID: 1599589431}
-  m_Layer: 0
-  m_Name: InputActionManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1599589430
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1599589429}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 378819497}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1599589431
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1599589429}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 017c5e3933235514c9520e1dace2a4b2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ActionAssets:
-  - {fileID: -944628639613478452, guid: 8c2d70d82cc8ac44ebf438e3e77ceac9, type: 3}
 --- !u!1 &1633348871
 GameObject:
   m_ObjectHideFlags: 0
@@ -6036,7 +5894,6 @@ Transform:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 82730832}
   - {fileID: 1566626495}
   - {fileID: 1211827615}
   - {fileID: 1795859455}

--- a/Assets/Scripts/Fruit/CheckGameOver.cs
+++ b/Assets/Scripts/Fruit/CheckGameOver.cs
@@ -6,25 +6,23 @@ using UnityEngine.SceneManagement;
 
 public class CheckGameOver : MonoBehaviour
 {
-    private bool inBowl = false;
+    public bool InBowl { get; private set; }
 
     public void TopggleInBowl()
     {
-        inBowl = !inBowl;
+        InBowl = !InBowl;
     }
 
-    // TODO: 접시 닿은건 Trigger로 처리
     private void OnCollisionEnter(Collision collision)
     {
-        Debug.Log($"충돌됨 {collision.gameObject.tag}");
-        if (!inBowl && collision.gameObject.CompareTag("Bowl"))
+        if (!InBowl && collision.gameObject.CompareTag("Bowl"))
         {
-            inBowl = true;
+            InBowl = true;
         }
 
-        if (inBowl && collision.gameObject.CompareTag("Plane"))
+        if (InBowl && collision.gameObject.CompareTag("Plane"))
         {
-            Managers.UI.ShowPopupUI<UIGameOver>().SetDialog(() => { SceneManager.LoadScene(0); }, "GameOver", Managers.ScoreManager.Score.ToString(), Managers.ScoreManager.BestScore.ToString(), "ReStart");
+            Managers.GameManager.EnableGameOverDialog();
         }
     }
 }

--- a/Assets/Scripts/Fruit/MergeFruit.cs
+++ b/Assets/Scripts/Fruit/MergeFruit.cs
@@ -9,7 +9,9 @@ public class MergeFruit : MonoBehaviour
 
     void OnCollisionEnter(Collision collision)
     {
-        if (!isMerged && collision.gameObject.CompareTag("Fruit"))
+        bool isPlacedOnBowl = GetComponent<CheckGameOver>().InBowl;
+
+        if (isPlacedOnBowl && !isMerged && collision.gameObject.CompareTag("Fruit"))
         {
             MergeFruit otherFruit = collision.gameObject.GetComponent<MergeFruit>();
 

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -1,12 +1,30 @@
-using System.Collections;
-using UnityEngine;
-using UnityEngine.UI;
-using TMPro;
-using System;
+using UnityEngine.SceneManagement;
+using UnityEngine.XR.ARFoundation;
 
-public class GameManager : MonoBehaviour
+public class GameManager
 {
-    
+    public bool isGameOverDialogEnabled = false;
 
+    public void EnableGameOverDialog()
+    {
+        if (isGameOverDialogEnabled == false)
+        {
+            isGameOverDialogEnabled = true;
+            Managers.UI.ShowPopupUI<UIGameOver>().SetDialog(
+                ReloadGameScene,
+                "GameOver",
+                Managers.ScoreManager.Score,
+                Managers.ScoreManager.BestScore,
+                "ReStart");
+        }
+    }
 
+    private void ReloadGameScene()
+    {
+        Managers.ScoreManager.ResetAll();
+        isGameOverDialogEnabled = false;
+        SceneManager.LoadScene(0);
+        LoaderUtility.Deinitialize();
+        LoaderUtility.Initialize();
+    }
 }

--- a/Assets/Scripts/Manager/Managers.cs
+++ b/Assets/Scripts/Manager/Managers.cs
@@ -14,13 +14,15 @@ public class Managers : MonoBehaviour
     private static FruitRandomSpawnManager fruitRandomSpawnManager = new();
     private static ScoreManager scoreManager = new();
     private static FruitsManager fruitsManager = new();
+    private static GameManager gameManager = new();
 
     public static DataManager Data { get { Init(); return dataManager; } }
     public static UIManager UI { get { Init(); return uiManager; } }
     public static ResourceManager Resource { get { Init(); return resourceManager; } }
     public static FruitRandomSpawnManager FruitRandomSpawnManager { get { Init(); return fruitRandomSpawnManager; } }
-    public static ScoreManager ScoreManager { get { Init();return scoreManager; } }
-    public static FruitsManager FruitsManager { get { Init();return fruitsManager; } }
+    public static ScoreManager ScoreManager { get { Init(); return scoreManager; } }
+    public static FruitsManager FruitsManager { get { Init(); return fruitsManager; } }
+    public static GameManager GameManager { get { Init(); return gameManager; } }
 
     void Start()
     {

--- a/Assets/Scripts/Manager/ScoreManager.cs
+++ b/Assets/Scripts/Manager/ScoreManager.cs
@@ -11,8 +11,8 @@ public class ScoreManager
     private float comboDuration = 3f;
     private float comboMulti = 1.1f;
 
-    public float Score { get; private set; }
-    public float BestScore { get; private set; }
+    public int Score { get; private set; }
+    public int BestScore { get; private set; }
 
     private Coroutine comboCoroutine;
 
@@ -58,7 +58,7 @@ public class ScoreManager
     private void UpdateScore(FruitsData fruitData)
     {
         int points = fruitData.level; // level을 점수로 사용
-        float scorePlus = Mathf.CeilToInt(points * comboMulti);
+        int scorePlus = Mathf.CeilToInt(points * comboMulti);
         Score += scorePlus;
         Debug.Log($"점수 : {Score}");
 
@@ -83,5 +83,12 @@ public class ScoreManager
 
         //if ( 리셋 여부 확인)
         OnComboUpdated?.Invoke(comboCount, comboMulti);
+    }
+
+    public void ResetAll()
+    {
+        ResetCombo();
+        Score = 0;
+        BestScore = 0;
     }
 }

--- a/Assets/Scripts/Scene/InGameScene.cs
+++ b/Assets/Scripts/Scene/InGameScene.cs
@@ -1,7 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class InGameScene : BaseScene
 {
@@ -11,9 +8,19 @@ public class InGameScene : BaseScene
             return false;
 
         SceneType = Define.Scene.Game;
-        Managers.UI.ShowPopupUI<UIConfirmDialog>().SetDialog(() => { Managers.UI.ShowPopupUI<UISetPlatePosition>(); }, "Info", "Please detect the floor to start game", "Enter");
+        Managers.UI.ShowPopupUI<UIConfirmDialog>().SetDialog(
+            MoveToInstallBowlStep,
+            "Info",
+            "Please detect the floor to start game",
+            "Enter");
+
         Debug.Log("Init");
 
         return true;
+    }
+
+    private void MoveToInstallBowlStep()
+    {
+        Managers.UI.ShowPopupUI<UISetPlatePosition>();
     }
 }

--- a/Assets/Scripts/UI/Popup/UIGameOver.cs
+++ b/Assets/Scripts/UI/Popup/UIGameOver.cs
@@ -39,12 +39,12 @@ public class UIGameOver : UIPopup
         return true;
     }
 
-    public void SetDialog(Action onClickYesButton, string title, string best, string score, string confirm)
+    public void SetDialog(Action onClickYesButton, string title, int bestScore, int currentScore, string confirm)
     {
         _onClickYesButton = onClickYesButton;
         _title = title;
-        _best = best;
-        _score = score;
+        _best = bestScore.ToString();
+        _score = currentScore.ToString();
         _confirm = confirm;
     }
 

--- a/Assets/Scripts/UI/Popup/UISetPlatePosition.cs
+++ b/Assets/Scripts/UI/Popup/UISetPlatePosition.cs
@@ -41,7 +41,11 @@ public class UISetPlatePosition : UIPopup
             if (_isDialogShowing == false)
             {
                 _isDialogShowing = true;
-                Managers.UI.ShowPopupUI<UIConfirmDialog>().SetDialog(() => { _isDialogShowing = false; }, "Info", "Please add a bowl in world with touch.", "Confirm");
+                Managers.UI.ShowPopupUI<UIConfirmDialog>().SetDialog(
+                    () => { _isDialogShowing = false; },
+                    "Info",
+                    "Please add a bowl in world with touch.",
+                    "Confirm");
             }
             return;
         }

--- a/Assets/Scripts/Util/ARSceneUtils.cs
+++ b/Assets/Scripts/Util/ARSceneUtils.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ARSceneUtils : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Util/ARSceneUtils.cs.meta
+++ b/Assets/Scripts/Util/ARSceneUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87d21865ec7c91d49853d01e4fb3304e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 작업내용
게임오버 후 다이얼로그 버튼 클릭 시 카메라를 다시 초기화 하도록 개선
씬 번호는 현재 씬이 하나만 있어서 0으로만 처리했지만 메인 화면도 추가한다면 씬 인덱스를 불러오는 코드만 변경하면 됨.

아래의 코드를 통해 AR기능을 다시 초기화 하도록 지정함.
```cs
LoaderUtility.Deinitialize();
LoaderUtility.Initialize();
```