### PR TITLE
AR-167 그릇 안에 있는 과일과 충돌 후 떨어지는 과일 처리

### DIFF
--- a/Assets/Scripts/Fruit/CheckGameOver.cs
+++ b/Assets/Scripts/Fruit/CheckGameOver.cs
@@ -8,7 +8,7 @@ public class CheckGameOver : MonoBehaviour
 {
     public bool InBowl { get; private set; }
 
-    public void TopggleInBowl()
+    public void ToggleInBowl()
     {
         InBowl = !InBowl;
     }

--- a/Assets/Scripts/Fruit/MergeFruit.cs
+++ b/Assets/Scripts/Fruit/MergeFruit.cs
@@ -19,6 +19,12 @@ public class MergeFruit : MonoBehaviour
             {
                 MergeFruits(collision.gameObject);
             }
+
+            if (otherFruit != null && otherFruit.GetComponent<CheckGameOver>().InBowl && !gameObject.GetComponent<CheckGameOver>().InBowl)
+            {
+                // 자기자신을 true로 변경
+                gameObject.GetComponent<CheckGameOver>().ToggleInBowl();
+            }
         }
     }
 

--- a/Assets/Scripts/Manager/FruitsManager.cs
+++ b/Assets/Scripts/Manager/FruitsManager.cs
@@ -15,7 +15,7 @@ public class FruitsManager
                 fruitInstance.GetComponent<ThrowFruit>().enabled = false;
                 Collider[] colliders = fruitInstance.GetComponents<Collider>();
                 fruitInstance.GetComponent<Rigidbody>().useGravity = true;
-                fruitInstance.GetComponent<CheckGameOver>().TopggleInBowl();
+                fruitInstance.GetComponent<CheckGameOver>().ToggleInBowl();
 
                 foreach (Collider collider in colliders)
                 {


### PR DESCRIPTION
## 작업 내용
그릇안에 있는 과일(이미 IsBowl이 True인 과일)에 닿으면 IsBowl 플래그를 True로 바꾸도록 구현
과일이 쌓여있을때 그릇 밖으로 과일이 떨어지지만 게임 오버  처리가 되지 않기 때문에 필요하다
![FruitFlagChange](https://github.com/user-attachments/assets/426963a2-7067-43ef-8522-e581986f4bc0)

> **MergeFruit 에 코드 추가**
> ```cs
> if (otherFruit != null && otherFruit.GetComponent<CheckGameOver>().InBowl && !gameObject.GetComponent<CheckGameOver>().InBowl)
> {
>     // 자기자신을 true로 변경
>     gameObject.GetComponent<CheckGameOver>().ToggleInBowl();
> }
> ```