### PR TITLE
AR-170 과일 랜덤 생성 범위 제한

### DIFF
--- a/Assets/Scripts/UI/FruitRandomSpawn.cs
+++ b/Assets/Scripts/UI/FruitRandomSpawn.cs
@@ -11,6 +11,7 @@ public class FruitRandomSpawnManager
     private Stack<int> randomIndex = new Stack<int>();
     private GameObject currentFruit;
     private GameObject nextFruit;
+    private int maxRange = 6;
 
     public delegate void OnChangeRandom(string fruitName);
     public event OnChangeRandom OnChangeRandomEvent;
@@ -24,8 +25,8 @@ public class FruitRandomSpawnManager
     void MakeRandomIndex()
     {
         randomIndex.Clear();
-        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length - 6));
-        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length - 6));
+        randomIndex.Push(UnityEngine.Random.Range(0, maxRange));
+        randomIndex.Push(UnityEngine.Random.Range(0, maxRange));
     }
 
     public void SpawnFruits()
@@ -51,7 +52,7 @@ public class FruitRandomSpawnManager
         }
 
         // 새로운 랜덤 인덱스 추가
-        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length - 6));
+        randomIndex.Push(UnityEngine.Random.Range(0, maxRange));
 
         // 다음 과일 이미지 업데이트
         OnChangeRandomEvent?.Invoke(Managers.Data.fruits[randomIndex.Peek()].name);

--- a/Assets/Scripts/UI/FruitRandomSpawn.cs
+++ b/Assets/Scripts/UI/FruitRandomSpawn.cs
@@ -24,8 +24,8 @@ public class FruitRandomSpawnManager
     void MakeRandomIndex()
     {
         randomIndex.Clear();
-        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length));
-        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length));
+        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length - 6));
+        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length - 6));
     }
 
     public void SpawnFruits()
@@ -51,7 +51,7 @@ public class FruitRandomSpawnManager
         }
 
         // 새로운 랜덤 인덱스 추가
-        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length));
+        randomIndex.Push(UnityEngine.Random.Range(0, Managers.Data.fruits.Length - 6));
 
         // 다음 과일 이미지 업데이트
         OnChangeRandomEvent?.Invoke(Managers.Data.fruits[randomIndex.Peek()].name);


### PR DESCRIPTION
## 작업 내용
랜덤하게 생성되는 과일 중 바로 수박이나 고 레벨의 과일들이 나오지 않도록 스폰 범위 수정
![SetFruitsRandomSpawnRange](https://github.com/user-attachments/assets/7a6dac0a-1786-40d9-ad11-6b79361e3e6d)
