### PR TITLE
AR-190 소리 enum 정의 방식 변경, 과일 투척 효과음 추가

### DIFF
--- a/Assets/Scripts/Fruit/ThrowFruit.cs
+++ b/Assets/Scripts/Fruit/ThrowFruit.cs
@@ -83,6 +83,8 @@ public class ThrowFruit : MonoBehaviour
         Managers.FruitRandomSpawnManager.SpawnFruits();
         Managers.FruitRandomSpawnManager.EnableAllColliders(gameObject);
 
+        Managers.SoundManager.Play(Define.Sound.Throw, "Throw");
+
         // �� ���� Throw �ǵ��� �̺�Ʈ ���� ����
         _swipeEventAsset.eventRaised -= Throw;
     }

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -47,7 +47,7 @@ public class GameManager
     {
         Managers.ScoreManager.ResetAll();
         isGameOverDialogEnabled = false;
-        SceneManager.LoadScene("Main");
+        SceneManager.LoadScene(0);
         Managers.UI.ShowPopupUI<UIMain>();
         LoaderUtility.Deinitialize();
     }
@@ -56,7 +56,7 @@ public class GameManager
     {
         Managers.ScoreManager.ResetAll();
         isGameOverDialogEnabled = false;
-        SceneManager.LoadScene(0);
+        SceneManager.LoadScene(1);
         LoaderUtility.Deinitialize();
         LoaderUtility.Initialize();
     }

--- a/Assets/Scripts/Manager/ScoreManager.cs
+++ b/Assets/Scripts/Manager/ScoreManager.cs
@@ -9,8 +9,6 @@ public class ScoreManager
     private float comboDuration = 3f;
     private float comboMulti = 1.1f;
 
-    private float audioPitch = 1.0f;
-
     public int Score { get; private set; }
     public int BestScore { get; private set; }
 
@@ -43,15 +41,6 @@ public class ScoreManager
             comboMulti = 1.1f;
         }
         comboTimer = comboDuration;
-        Debug.Log($"점수 멀티플 : {comboMulti}");
-
-        audioPitch += 0.1f;
-        if (audioPitch >= 2.0)
-        {
-            audioPitch = 2.0f;
-        }
-
-        Managers.SoundManager.Play(Define.Sound.Effect, "Combo", 1.0f, audioPitch);
 
         if (comboCoroutine != null)
         {
@@ -59,6 +48,8 @@ public class ScoreManager
         }
 
         comboCoroutine = Managers.Instance.StartCoroutine(ComboResetCoroutine());
+        Managers.SoundManager.Play(Define.Sound.Merge, "Combo", 1.0f, comboMulti >= 2.0 ? 2.0f : comboMulti);
+
 
         OnComboUpdated?.Invoke(comboCount, comboMulti);
     }
@@ -84,7 +75,6 @@ public class ScoreManager
         comboCount = 0;
         comboMulti = 1.1f;
         comboTimer = 0f;
-        audioPitch = 1.0f;
     }
 
     public void ResetAll()

--- a/Assets/Scripts/Manager/SoundManager.cs
+++ b/Assets/Scripts/Manager/SoundManager.cs
@@ -25,10 +25,12 @@ public class SoundManager
                 {
                     GameObject go = new GameObject { name = soundTypeNames[i] };
                     _audioSources[i] = go.AddComponent<AudioSource>();
+                    _audioSources[i].playOnAwake = false;
                     go.transform.parent = _soundRoot.transform;
                 }
 
                 _audioSources[(int)Define.Sound.Bgm].loop = true;
+                _audioSources[(int)Define.Sound.Bgm].playOnAwake = true;
             }
         }
     }
@@ -49,6 +51,8 @@ public class SoundManager
         if (path.Contains("Audio/") == false)
             path = string.Format("Audio/{0}", path);
 
+        audioSource.volume = volume;
+
         if (type == Define.Sound.Bgm)
         {
             AudioClip audioClip = Managers.Resource.Load<AudioClip>(path);
@@ -58,20 +62,18 @@ public class SoundManager
             if (audioSource.isPlaying)
                 audioSource.Stop();
 
-            audioSource.volume = volume;
+            audioSource.clip = audioClip;
             audioSource.pitch = pitch;
-
             audioSource.Play();
             return true;
         }
-        else if (type == Define.Sound.Effect)
+        else if (type == Define.Sound.Throw || type == Define.Sound.Merge)
         {
             AudioClip audioClip = GetAudioClip(path);
             if (audioClip == null)
                 return false;
 
             audioSource.pitch = pitch;
-
             audioSource.PlayOneShot(audioClip);
             return true;
         }

--- a/Assets/Scripts/Util/Define.cs
+++ b/Assets/Scripts/Util/Define.cs
@@ -18,6 +18,7 @@ public class Define
     public enum Sound
     {
         Bgm,
-        Effect
+        Merge,
+        Throw
     }
 }


### PR DESCRIPTION
## 작업내용
- 소리 채널 enum 정의 방식 변경
- 과일 투척 효과음 추가

## 매니저 사용방법 변경 사항
기존에는 Effects와 Bgm만 있었는데, 이런 형식으로 진행하니 Pitch가 올라간 상태여도 소리를 동시에 재생하면 1.0으로 변경되는 이슈가 발생하여 재생하고 싶은 음원의 이름을 enum에 추가하는 방식으로 변경함.
### 예시
```cs
// Util/Define.cs //
// ,,,
public enum Sound
{
    Bgm,
    Merge,
    Throw,
    // 여기서부터 사용하고 싶은 소리의 정의를 추가해주면 됨.
}

// Manager/SoundManager.cs //
public bool Play(Define.Sound type, string path, float volume = 1.0f, float pitch = 1.0f)
{
    // ...

    if (type == Define.Sound.Bgm)
    {
        AudioClip audioClip = Managers.Resource.Load<AudioClip>(path);
        if (audioClip == null)
            return false;

        if (audioSource.isPlaying)
            audioSource.Stop();

        audioSource.clip = audioClip;
        audioSource.pitch = pitch;
        audioSource.Play();
        return true;
    }
    // PlayOneShot인 경우 여기서 || 연산자로 추가해줘도 됨.
    else if (type == Define.Sound.Throw || type == Define.Sound.Merge)
    {
        AudioClip audioClip = GetAudioClip(path);
        if (audioClip == null)
            return false;

        audioSource.pitch = pitch;
        audioSource.PlayOneShot(audioClip);
        return true;
    }
    // 만약 별도로 특정 채널에 처리를 더 해주고 싶다면 여기에 조건 더 추가해주면 됨.

    return false;
}
```